### PR TITLE
Center app layout with AppWrapper

### DIFF
--- a/vite-react/src/App.css
+++ b/vite-react/src/App.css
@@ -1,6 +1,6 @@
 .container {
   max-width: 600px;
-  margin: 2rem auto;
+  margin: 0 auto;
   padding: 1rem;
   font-family: system-ui, sans-serif;
   color: #333;

--- a/vite-react/src/App.jsx
+++ b/vite-react/src/App.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import AppWrapper from './AppWrapper.jsx'
 import './App.css'
 
 const STATES = ['Pendiente', 'In Progress', 'Completada']
@@ -31,12 +32,13 @@ export default function App() {
   }
 
   return (
-    <div className="container">
-      <h1>TODO List</h1>
-      <form onSubmit={addTask} className="add-form">
-        <input
-          placeholder="Nueva tarea"
-          value={text}
+    <AppWrapper>
+      <div className="container">
+        <h1>TODO List</h1>
+        <form onSubmit={addTask} className="add-form">
+          <input
+            placeholder="Nueva tarea"
+            value={text}
           onChange={(e) => setText(e.target.value)}
         />
         <button>Añadir</button>
@@ -58,6 +60,7 @@ export default function App() {
           </li>
         ))}
       </ul>
-    </div>
+      </div>
+    </AppWrapper>
   )
 }

--- a/vite-react/src/AppWrapper.jsx
+++ b/vite-react/src/AppWrapper.jsx
@@ -1,0 +1,3 @@
+export default function AppWrapper({ children }) {
+  return <div className="app-wrapper">{children}</div>
+}

--- a/vite-react/src/index.css
+++ b/vite-react/src/index.css
@@ -13,6 +13,12 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 a {
   font-weight: 500;
   color: #646cff;
@@ -22,12 +28,27 @@ a:hover {
   color: #535bf2;
 }
 
+html,
 body {
   margin: 0;
+  padding: 0;
+}
+
+body {
   display: flex;
-  place-items: center;
+  align-items: center;
+  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
+}
+
+.app-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  width: 100%;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- add `AppWrapper` component
- globally center layout and reset base styles
- remove top margin from main container

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684304ed7a38832389eb94365bc28e4e