### PR TITLE
Implement task cards

### DIFF
--- a/vite-react/src/App.css
+++ b/vite-react/src/App.css
@@ -35,14 +35,28 @@
 }
 
 .task {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.5rem;
-  margin-bottom: 0.5rem;
-  border-radius: 4px;
-  background-color: #f2f2f2;
   animation: fade-in 0.3s ease-out;
+}
+
+.task-card {
+  background-color: var(--secundario);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.task-card:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+  background-color: #2A2A2A;
+}
+
+.task-card span {
+  color: #FFFFFF;
+  font-weight: 400;
 }
 
 .task.pendiente {

--- a/vite-react/src/App.jsx
+++ b/vite-react/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import AppWrapper from './AppWrapper.jsx'
+import TaskItem from './TaskItem.jsx'
 import './App.css'
 
 const STATES = ['Pendiente', 'In Progress', 'Completada']
@@ -45,19 +46,12 @@ export default function App() {
       </form>
       <ul className="task-list">
         {tasks.map((task) => (
-          <li key={task.id} className={`task ${task.state.toLowerCase().replace(' ', '-')}`}>
-            <span>{task.text}</span>
-            <select
-              value={task.state}
-              onChange={(e) => updateTask(task.id, e.target.value)}
-            >
-              {STATES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-          </li>
+          <TaskItem
+            key={task.id}
+            task={task}
+            states={STATES}
+            onChange={updateTask}
+          />
         ))}
       </ul>
       </div>

--- a/vite-react/src/TaskItem.jsx
+++ b/vite-react/src/TaskItem.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function TaskItem({ task, states, onChange }) {
+  return (
+    <li className={`task ${task.state.toLowerCase().replace(' ', '-')}`}> 
+      <div className="task-card">
+        <span className="task-text">{task.text}</span>
+        <select value={task.state} onChange={e => onChange(task.id, e.target.value)}>
+          {states.map(s => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+      </div>
+    </li>
+  )
+}

--- a/vite-react/src/index.css
+++ b/vite-react/src/index.css
@@ -6,6 +6,7 @@
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
+  --secundario: #3a3a3a;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
- create `TaskItem` component to display each task in a card
- style `.task-card` with rounded corners, dark background and hover effect
- update task list to use new component
- add `--secundario` CSS variable for card background

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6843066827008323ab8a209a4b19f536