### PR TITLE
Add vibrant styles for add button

### DIFF
--- a/vite-react/src/App.css
+++ b/vite-react/src/App.css
@@ -19,13 +19,27 @@
   border: 1px solid #ccc;
 }
 
-.add-form button {
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  background-color: #646cff;
-  color: #fff;
+
+.add-button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 500;
   border: none;
+  border-radius: 0.5rem;
+  background-color: var(--primario);
+  color: #FFFFFF;
   cursor: pointer;
+  transition: background-color 0.2s, transform 0.1s;
+}
+.add-button:hover {
+  background-color: var(--hover-primario);
+}
+.add-button:active {
+  transform: scale(0.97);
+}
+.add-button:disabled {
+  background-color: #555555;
+  cursor: not-allowed;
 }
 
 .task-list {

--- a/vite-react/src/App.jsx
+++ b/vite-react/src/App.jsx
@@ -39,10 +39,15 @@ export default function App() {
           <input
             placeholder="Nueva tarea"
             value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
-        <button>Añadir</button>
-      </form>
+            onChange={(e) => setText(e.target.value)}
+          />
+          <button
+            className="add-button"
+            disabled={!text.trim()}
+          >
+            Añadir
+          </button>
+        </form>
       <ul className="task-list">
         {tasks.map((task) => (
           <li key={task.id} className={`task ${task.state.toLowerCase().replace(' ', '-')}`}>

--- a/vite-react/src/index.css
+++ b/vite-react/src/index.css
@@ -3,6 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
+  --primario: #7e22ce;
+  --hover-primario: #9333ea;
+
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;


### PR DESCRIPTION
## Summary
- style Add button via new `.add-button` class
- enable disabled state when input is empty
- define purple CSS variables

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684306a3dc288323b75d2be20187648b