### PR TITLE
Add dark theme style for status dropdown

### DIFF
--- a/vite-react/src/App.css
+++ b/vite-react/src/App.css
@@ -43,6 +43,7 @@
   border-radius: 4px;
   background-color: #f2f2f2;
   animation: fade-in 0.3s ease-out;
+  transition: background-color 0.3s, color 0.3s;
 }
 
 .task.pendiente {
@@ -56,6 +57,8 @@
 .task.completada {
   border-left: 4px solid seagreen;
   text-decoration: line-through;
+  background-color: #333;
+  color: #bfbfbf;
 }
 
 @keyframes fade-in {
@@ -67,4 +70,21 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.status-select {
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  background-color: #1E1E1E;
+  color: #FFFFFF;
+  border: none;
+  border-radius: 0.5rem;
+  outline: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  margin-left: auto;
+}
+
+.status-select:hover {
+  background-color: #2A2A2A;
 }

--- a/vite-react/src/App.jsx
+++ b/vite-react/src/App.jsx
@@ -48,6 +48,7 @@ export default function App() {
           <li key={task.id} className={`task ${task.state.toLowerCase().replace(' ', '-')}`}>
             <span>{task.text}</span>
             <select
+              className="status-select"
               value={task.state}
               onChange={(e) => updateTask(task.id, e.target.value)}
             >


### PR DESCRIPTION
## Summary
- add `status-select` class and apply dark theme styles
- animate tasks when status changes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684306c4fdc083238bbe8679a8f98fe6