### PR TITLE
Add completed task visual indicator

### DIFF
--- a/vite-react/src/App.css
+++ b/vite-react/src/App.css
@@ -34,7 +34,7 @@
   margin: 0;
 }
 
-.task {
+.task-card {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -43,19 +43,25 @@
   border-radius: 4px;
   background-color: #f2f2f2;
   animation: fade-in 0.3s ease-out;
+  transition: all 0.2s ease-in-out;
 }
 
-.task.pendiente {
+.task-card.pendiente {
   border-left: 4px solid orange;
 }
 
-.task.in-progress {
+.task-card.in-progress {
   border-left: 4px solid dodgerblue;
 }
 
-.task.completada {
+.task-card.completada {
   border-left: 4px solid seagreen;
+}
+
+.task-card.completed {
+  opacity: 0.6;
   text-decoration: line-through;
+  background-color: #181818;
 }
 
 @keyframes fade-in {

--- a/vite-react/src/App.jsx
+++ b/vite-react/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import AppWrapper from './AppWrapper.jsx'
+import TaskItem from './TaskItem.jsx'
 import './App.css'
 
 const STATES = ['Pendiente', 'In Progress', 'Completada']
@@ -39,25 +40,13 @@ export default function App() {
           <input
             placeholder="Nueva tarea"
             value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
-        <button>Añadir</button>
-      </form>
+            onChange={(e) => setText(e.target.value)}
+          />
+          <button>Añadir</button>
+        </form>
       <ul className="task-list">
         {tasks.map((task) => (
-          <li key={task.id} className={`task ${task.state.toLowerCase().replace(' ', '-')}`}>
-            <span>{task.text}</span>
-            <select
-              value={task.state}
-              onChange={(e) => updateTask(task.id, e.target.value)}
-            >
-              {STATES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-          </li>
+          <TaskItem key={task.id} task={task} states={STATES} onChange={updateTask} />
         ))}
       </ul>
       </div>

--- a/vite-react/src/TaskItem.jsx
+++ b/vite-react/src/TaskItem.jsx
@@ -1,0 +1,18 @@
+export default function TaskItem({ task, states, onChange }) {
+  const isCompleted = task.state === 'Completada'
+  const stateClass = task.state.toLowerCase().replace(' ', '-')
+  return (
+    <li className="task-item">
+      <div className={`task-card ${stateClass} ${isCompleted ? 'completed' : ''}`}>
+        <span>{task.text}</span>
+        <select value={task.state} onChange={(e) => onChange(task.id, e.target.value)}>
+          {states.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+    </li>
+  )
+}


### PR DESCRIPTION
## Summary
- add `TaskItem` component for task rendering
- show tasks using `TaskItem` in `App`
- dim card and strike-through text when task is completed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684306d5dec8832398902b827bd6db46