### PR TITLE
Add mobile responsive styles

### DIFF
--- a/vite-react/src/App.css
+++ b/vite-react/src/App.css
@@ -43,6 +43,8 @@
   border-radius: 4px;
   background-color: #f2f2f2;
   animation: fade-in 0.3s ease-out;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .task.pendiente {

--- a/vite-react/src/index.css
+++ b/vite-react/src/index.css
@@ -2,6 +2,7 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  --espaciado-pequeno: 0.5rem;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
@@ -85,5 +86,38 @@ button:focus-visible {
   }
   button {
     background-color: #f9f9f9;
+  }
+}
+
+@media (max-width: 768px) {
+  h1 {
+    font-size: 2.25rem;
+  }
+  .add-form {
+    flex-direction: column;
+    gap: var(--espaciado-pequeno);
+  }
+  .add-form input,
+  .add-form button {
+    width: 100%;
+    max-width: none;
+  }
+}
+
+@media (max-width: 480px) {
+  h1 {
+    font-size: 2rem;
+  }
+  .app-subtitle {
+    font-size: 1rem;
+  }
+  .task {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--espaciado-pequeno);
+  }
+  .task select {
+    margin-left: 0;
+    align-self: flex-end;
   }
 }


### PR DESCRIPTION
## Summary
- make global spacing variable
- ensure task cards fit container
- add responsive breakpoints for tablet and phone

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684306e97024832396003206cbc3c904