### PR TITLE
Add icon buttons for tasks

### DIFF
--- a/vite-react/package-lock.json
+++ b/vite-react/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2459,6 +2460,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/vite-react/package.json
+++ b/vite-react/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/vite-react/src/App.css
+++ b/vite-react/src/App.css
@@ -58,6 +58,31 @@
   text-decoration: line-through;
 }
 
+.delete-button,
+.complete-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.2s;
+  margin-left: 0.25rem;
+}
+
+.delete-button {
+  color: #ff4e4e;
+}
+
+.delete-button:hover {
+  color: #ff1e1e;
+}
+
+.complete-button {
+  color: seagreen;
+}
+
+.complete-button:hover {
+  color: #2e8b57;
+}
+
 @keyframes fade-in {
   from {
     opacity: 0;

--- a/vite-react/src/App.jsx
+++ b/vite-react/src/App.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { FiTrash2, FiCheckCircle } from 'react-icons/fi'
 import AppWrapper from './AppWrapper.jsx'
 import './App.css'
 
@@ -31,6 +32,14 @@ export default function App() {
     setTasks((ts) => ts.map((t) => (t.id === id ? { ...t, state } : t)))
   }
 
+  function deleteTask(id) {
+    setTasks((ts) => ts.filter((t) => t.id !== id))
+  }
+
+  function completeTask(id) {
+    updateTask(id, 'Completada')
+  }
+
   return (
     <AppWrapper>
       <div className="container">
@@ -45,7 +54,10 @@ export default function App() {
       </form>
       <ul className="task-list">
         {tasks.map((task) => (
-          <li key={task.id} className={`task ${task.state.toLowerCase().replace(' ', '-')}`}>
+          <li
+            key={task.id}
+            className={`task ${task.state.toLowerCase().replace(' ', '-')}`}
+          >
             <span>{task.text}</span>
             <select
               value={task.state}
@@ -57,6 +69,20 @@ export default function App() {
                 </option>
               ))}
             </select>
+            <button
+              className="complete-button"
+              onClick={() => completeTask(task.id)}
+              title="Completar"
+            >
+              <FiCheckCircle size={18} />
+            </button>
+            <button
+              className="delete-button"
+              onClick={() => deleteTask(task.id)}
+              title="Eliminar"
+            >
+              <FiTrash2 size={18} />
+            </button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add `react-icons` dependency
- use `FiCheckCircle` and `FiTrash2` to complete or delete tasks
- style new icon buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684307042b908323b13b40f788cb8d42